### PR TITLE
Add support for tar.bz2 name resolution

### DIFF
--- a/pipdownload/utils.py
+++ b/pipdownload/utils.py
@@ -191,6 +191,9 @@ def resolve_package_file(name: str) -> PythonPackage:
     if name.endswith(".tar.gz"):
         result = re.search(r"(?<=-)[^-]+?(?=\.tar\.gz)", name)
 
+    if name.endswith(".tar.bz2"):
+        result = re.search(r"(?<=-)[^-]+?(?=\.tar\.bz2)", name)
+
     if name.endswith(".zip"):
         result = re.search(r"(?<=-)[^-]+?(?=\.zip)", name)
 


### PR DESCRIPTION
Hi! Amazing project, that solves a very real need, so thank you very much for publishing it!

I discovered attempting to download the package `prettytable` that tar.bz2 extensions were not supported, so this commit attempts to fix that.

The error message that I got:
```
Can not resolve a package's name and version from a downloaded package. You shuold create an issue maybe.
```

But instead of creating the issue, the code change was easy enough to fix it :smile: 
